### PR TITLE
Allow configurable port

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # NODE_JS_2
+
+## Running the project
+
+```bash
+cd hw_1
+npm start
+```
+
+The server listens on the port defined by the `PORT` environment variable or defaults to `3000`.

--- a/hw_1/index.js
+++ b/hw_1/index.js
@@ -9,6 +9,7 @@ const server = http.createServer((req, res) => {
   res.writeHead(404).end('Not found');
 });
 
-server.listen(3000, () => {
-  console.log('🚀  http://localhost:3000');
+const port = process.env.PORT || 3000;
+server.listen(port, () => {
+  console.log(`🚀  http://localhost:${port}`);
 });


### PR DESCRIPTION
## Summary
- let hw_1 server listen on process.env.PORT or default 3000
- document running the project and the new PORT variable

## Testing
- `npm test` *(fails: missing package.json)*
- `npm test` in `hw_1` *(fails: missing script)*
- `npm run lint` *(fails: missing script)*
- `PORT=9999 node index.js`

------
https://chatgpt.com/codex/tasks/task_e_6851a9c2267483329d21a759b3d8334d